### PR TITLE
Changed authenticatorData flag checking to properly check flag

### DIFF
--- a/src/webauthn.php
+++ b/src/webauthn.php
@@ -283,7 +283,7 @@ class WebAuthn {
     /* experience shows that at least one device (OnePlus 6T/Pie (Android phone)) doesn't set this, 
        so this test would fail. This is not correct according to the spec, so  pragmatically it may 
        have to be removed */
-    if ($ao->flags != 0x1) { $this->oops('cannot decode key response (2c)'); } /* only TUP must be set */
+    if (($ao->flags & 0x1) != 0x1) { $this->oops('cannot decode key response (2c)'); } /* only TUP must be set */
 
     /* assemble signed data */
     $clientdata = self::array_to_string($info->response->clientDataJSONarray);


### PR DESCRIPTION
After attempting to use the lib on Edge I had noticed all my requests were being denied with `cannot decode key response (2c)`. Upon investigation I had noticed that the lib checked directly against the variable not being `0x1` and errorring consequently.

However, this would mean that if any other flags would passed, this check would immediately fail, as is the case with Microsoft Edge.
In my attempts, I had found that it would return the value: `5`, consequently 0b101. According to the [spec](https://www.w3.org/TR/webauthn/#authenticator-data) this means that the following flags have been set:
- User Present (UP) (the one the library wants to check for)
- User Verified (UV) (probably as a consequence of me entering the PIN)

The attached commit changes the detection to only quick for bit 0 being set, as opposed to checking for equality.