### PR TITLE
Strip https?:// prefix on AppId

### DIFF
--- a/WebAuthn/WebAuthn.php
+++ b/WebAuthn/WebAuthn.php
@@ -50,10 +50,8 @@ class WebAuthn
         if (! is_string($appid)) {
             $this->oops('appid must be a string');
         }
-        $this->appid = $appid;
-        if (strpos($this->appid, 'https://') === 0) {
-            $this->appid = substr($this->appid, 8); /* drop the https:// */
-        }
+        // "http://localhost" is considered a secure domain, otherwise https is mandatory.
+        $this->appid = preg_replace('|^https?://|', '', $appid);
     }
 
     /**


### PR DESCRIPTION
Modification on the existing code to strip https:// prefix only - as http://localhost is considered a secure domain used for development and testing.
Love this project, thanks so much!